### PR TITLE
We should stop propagation of the event before returning the response

### DIFF
--- a/src/Routing/Filter/GlideFilter.php
+++ b/src/Routing/Filter/GlideFilter.php
@@ -54,7 +54,7 @@ class GlideFilter extends DispatcherFilter
                 $response->header($key, $value);
             }
         }
-        
+
         $event->stopPropagation();
 
         return $response;

--- a/src/Routing/Filter/GlideFilter.php
+++ b/src/Routing/Filter/GlideFilter.php
@@ -54,6 +54,8 @@ class GlideFilter extends DispatcherFilter
                 $response->header($key, $value);
             }
         }
+        
+        $event->stopPropagation();
 
         return $response;
     }


### PR DESCRIPTION
According to: http://book.cakephp.org/3.0/en/development/dispatch-filters.html#building-a-filter

>"By returning an Response object, you can short-circuit the dispatch process and prevent the controller from being called. When returning a response, you should also remember to call $event->stopPropagation() so other filters are not called."