### PR TITLE
Make plugin compatible with FoC/Crud

### DIFF
--- a/deprecations.php
+++ b/deprecations.php
@@ -4,7 +4,8 @@ if (!class_exists('Cake\Http\Exception\ForbiddenException')) {
         'Cake\Network\Exception\ForbiddenException',
         'Cake\Http\Exception\ForbiddenException'
     );
-
+}
+if (!class_exists('Cake\Http\Exception\NotFoundException')) {
     class_alias(
         'Cake\Network\Exception\NotFoundException',
         'Cake\Http\Exception\NotFoundException'


### PR DESCRIPTION
They made a similar solution: https://github.com/FriendsOfCake/crud/blob/master/aliases.php

however I get following error 
```
PHP Warning:  Cannot declare class Cake\Http\Exception\NotFoundException, because the name is already in use in /var/www/apacta/vendor/friendsofcake/crud/aliases.php on line 17
PHP Stack trace:
PHP   1. {main}() /var/www/apacta/vendor/phpunit/phpunit/phpunit:0
PHP   2. require() /var/www/apacta/vendor/phpunit/phpunit/phpunit:51
PHP   3. ComposerAutoloaderInitc5f18fedf80ea89a4186f61d865fa6d8::getLoader() /var/www/apacta/vendor/autoload.php:7
PHP   4. composerRequirec5f18fedf80ea89a4186f61d865fa6d8() /var/www/apacta/vendor/composer/autoload_real.php:56
PHP   5. require() /var/www/apacta/vendor/composer/autoload_real.php:66
PHP   6. class_alias() /var/www/apacta/vendor/friendsofcake/crud/aliases.php:17
```