### PR TITLE
Allow for use with cakephp4

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,7 @@
         "issues":"https://github.com/ADmad/cakephp-glide/issues"
     },
     "require": {
-        "cakephp/cakephp": "^3.5",
+        "cakephp/cakephp": "^3.5|^4.0",
         "league/glide": "^1.3"
     },
     "require-dev": {


### PR DESCRIPTION
Right now it can't be installed with cakephp4. I haven't tested this but i assume it works with cakephp4.x-dev